### PR TITLE
Set dashboard ID to null

### DIFF
--- a/roles/prometheus-server/files/grafana_dashboard.json
+++ b/roles/prometheus-server/files/grafana_dashboard.json
@@ -6,7 +6,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "hideControls": false,
-  "id": 1,
+  "id": null,
   "links": [],
   "refresh": false,
   "rows": [


### PR DESCRIPTION
By setting the ID to null we create a new dashboard when this is
uploaded to Grafana. Previously, for a fresh install, the load would
fail because the dashboard didn't exist.